### PR TITLE
Add static compile flags for Python build

### DIFF
--- a/build_static_python_arm.sh
+++ b/build_static_python_arm.sh
@@ -45,6 +45,12 @@ export AR=${TARGET}-ar
 export RANLIB=${TARGET}-ranlib
 export READELF=${TARGET}-readelf
 
+# ⚙️ 靜態編譯選項
+export LDFLAGS="-static"
+export CFLAGS="-static"
+export CPPFLAGS="-static"
+
+LDFLAGS="$LDFLAGS" CFLAGS="$CFLAGS" CPPFLAGS="$CPPFLAGS" \
 ac_cv_file__dev_ptmx=yes ac_cv_file__dev_ptc=no ./configure \
   --host=$TARGET \
   --build=$(uname -m)-pc-linux-gnu \


### PR DESCRIPTION
## Summary
- ensure Python is built with static flags in `build_static_python_arm.sh`

## Testing
- `bash -n build_static_python_arm.sh`


------
https://chatgpt.com/codex/tasks/task_e_6863377b5de08321ba70a8d8f48d7ab2